### PR TITLE
Removed unneeded list(range(...))

### DIFF
--- a/hipsterplot3.py
+++ b/hipsterplot3.py
@@ -39,7 +39,7 @@ def yloop(ys, num_y_chars, y_bin_ends):
 
 def plot(y_vals, x_vals=None, num_x_chars=70, num_y_chars=15):
     if x_vals == None:
-        x_vals = list(range(len(y_vals)))
+        x_vals = range(len(y_vals))
     else:
         if len(x_vals) != len(y_vals):
             raise Exception("x_vals and y_vals must be the same length")


### PR DESCRIPTION
Python 3 range objects, while not lists, can be subscripted like lists. The `list` isn't needed.
