### PR TITLE
Add support for any iterable as input

### DIFF
--- a/hipsterplot.py
+++ b/hipsterplot.py
@@ -82,9 +82,9 @@ def plot(y_vals, x_vals=None, num_x_chars=70, num_y_chars=15):
     The num_x_chars and num_y_chars inputs are respectively the width and
     height for the output plot to be printed, given in characters.
     """
-    if x_vals is None:
-        x_vals = list(range(len(y_vals)))
-    elif len(x_vals) != len(y_vals):
+    y_vals = list(y_vals)
+    x_vals = list(x_vals) if x_vals else list(range(len(y_vals)))
+    if len(x_vals) != len(y_vals):
         raise ValueError("x_vals and y_vals must have the same length")
 
     ymin = min(y_vals)


### PR DESCRIPTION
This will make the following snippet work as expected in Python 3:

    >>> import math
    >>> from hipsterplot import plot
    >>> x = [x * 0.01 for x in range(1000)]
    >>> plot(map(math.sin, x))

Previously it would choke because `map()` return a lazy map object in Python 3 (as opposed to a list in Python 2), which doesn't support `len()`.